### PR TITLE
Add types for DPF calculation

### DIFF
--- a/mms_nirs/utils/dpf.py
+++ b/mms_nirs/utils/dpf.py
@@ -1,18 +1,25 @@
+from typing import Union
+
 import numpy as np
 
 
-def calc_dpf(mu_s: float, mu_a: float, d: float) -> float:
+def calc_dpf(
+    mu_s: Union[float, np.ndarray], mu_a: Union[float, np.ndarray], d: float
+) -> Union[float, np.ndarray]:
     """Calculate differential pathlength factor from mu_a and mu_s
+
+    If arrays are passed, output is an array. If floats are passed
+    output is a float
 
     Taken from https://doi.org/10.1117/1.JBO.18.10.105004
 
     Args:
-        mu_s (float): reduced scattering coefficient
-        mu_a (float): absorption coefficient
+        mu_s (float | np.ndarray): reduced scattering coefficient
+        mu_a (float | np.ndarray): absorption coefficient
         d (float): source-detector distance
 
     Returns:
-        float: differential pathlength factor
+        float | np.ndarray: differential pathlength factor
     """
 
     return (

--- a/tests/utils/test_dpf.py
+++ b/tests/utils/test_dpf.py
@@ -1,3 +1,4 @@
+import numpy as np
 import numpy.testing as npt
 import pytest
 
@@ -9,9 +10,23 @@ class TestDpf:
         "mu_s,mu_a,d",
         [(3.0, 4.0, 5.0), (3.0, 4, 5.0), (3, 4.0, 5.0), (3, 4, 5)],
     )
-    def test_calc_dpf(self, mu_s, mu_a, d):
+    def test_calc_dpf_float(self, mu_s, mu_a, d):
         expected = 0.6979759
 
         actual = calc_dpf(mu_s, mu_a, d)
 
         npt.assert_approx_equal(actual, expected)
+
+    @pytest.mark.parametrize(
+        "mu_s,mu_a,d",
+        [(3.0, 4.0, 5.0), (3.0, 4, 5.0), (3, 4.0, 5.0), (3, 4, 5)],
+    )
+    def test_calc_dpf_array(self, mu_s, mu_a, d):
+        expected = np.array([0.6979759, 0.6979759])
+
+        mu_s_arr = np.array([mu_s] * 2)
+        mu_a_arr = np.array([mu_a] * 2)
+
+        actual = calc_dpf(mu_s_arr, mu_a_arr, d)
+
+        npt.assert_array_almost_equal(actual, expected)


### PR DESCRIPTION
The DPF calculation was able to take arrays as well as floats but the type hints didn't reflect this.