### PR TITLE
fix: bug in score calculation

### DIFF
--- a/mms_nirs/BRUNO/calc_values.py
+++ b/mms_nirs/BRUNO/calc_values.py
@@ -46,14 +46,16 @@ def calc_values(
 
     Args:
         slope (np.ndarray): Attenuation slope
-        extinction (np.ndarray): Matrix of extinction co-efficients for each species
-        and wavelength
+        extinction (np.ndarray): Matrix of extinction co-efficients for each
+        species and wavelength
         wavelengths (np.ndarray): Wavelengths of light used
         boundaries (np.ndarray): Boundaries for parameters. First row is start,
         second is lower bound, third is upper bound
-        boundary_condition_type (BoundaryType): Zero or Extrapolated boundary condition
-        distance (float): Distance between source and detector. If one distance used
-        this is it. If maximal distance used, this is the minimal.
+        boundary_condition_type (BoundaryType): Zero or Extrapolated boundary
+        condition
+        distance (float): Distance between source and detector. If one
+        distance used this is it. If maximal distance used, this is the
+        minimal.
         distance_max (Optional[float], optional): Optional maximum distance.
         Defaults to None.
 
@@ -116,7 +118,7 @@ def calc_values(
         boundary_condition_type, QuantityType.ATTENUATION_SLOPE, distance_max
     )
     if distance_max:
-        model_result = model_function(distance_max, distance, mua, mus)
+        model_result = model_function(mus, mua, distance, distance_max)
     else:
         model_result = model_function(mua, mus, distance)
 

--- a/tests/BRUNO/test_calc_values.py
+++ b/tests/BRUNO/test_calc_values.py
@@ -4,7 +4,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from mms_nirs.BRUNO.calc_values import calc_values, smooth
+from mms_nirs.BRUNO.calc_values import calc_values
 from mms_nirs.BRUNO.derivative_fit import BoundaryType
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
@@ -101,7 +101,7 @@ class TestCalcValues:
                 2.555661423244912,
             ]
         )
-        expected_score = 33.85892581587063
+        expected_score = 0.152333965717711
 
         (
             stO2,
@@ -170,7 +170,7 @@ class TestCalcValues:
             ]
         )
 
-        expected_score = 57.2088269575511
+        expected_score = 0.151596628281833
 
         (
             stO2,


### PR DESCRIPTION
There was a bug in the calc_values code that produced the wrong score for long distance separation.